### PR TITLE
Add getter past and future reserves

### DIFF
--- a/app/Controller/history/index.php
+++ b/app/Controller/history/index.php
@@ -1,12 +1,20 @@
 <?php
 
+use Model\Dao\Reserve;
 use Slim\Http\Request;
 use Slim\Http\Response;
 
 // Historyページのコントローラ
 $app->get('/history/', function (Request $request, Response $response) {
 
-    $data = [];
+    // Reserve DAOをインスタンス化
+    $reserve = new Reserve($this->db);
+
+    // 各データを格納
+    $data = [
+        "past_reserve" => $reserve->getPastReserveByUser($this->session["user_info"]["id"]),
+        "future_reserve" => $reserve->getFutureReserveByUser($this->session["user_info"]["id"])
+    ];
 
     // Render index view
     return $this->view->render($response, 'history/index.twig', $data);

--- a/app/Model/Dao/Reserve.php
+++ b/app/Model/Dao/Reserve.php
@@ -53,6 +53,68 @@ class Reserve extends Dao
         return $statement->fetchAll();
     }
 
+    /**
+     * getPastReserveByVilla Function
+     *
+     * Reserveテーブルから指定user_idの今日までのレコードを全件取得するクエリです。
+     *
+     * @param int $user_id 引数として、取得したい予約記録を指定します。
+     * @return array $result 結果情報を連想配列を返します。
+     * @throws DBALException
+     * @author wkmkymt <wkmkymt@gmail.com>
+     * @since 2019/09/06
+     */
+    public function getPastReserveByUser($user_id)
+    {
+        // user_idを指定して取得するクエリを作成
+        $sql = "select reserve.date, villa.id, villa.name, villa.image_path
+                    from reserve inner join villa on reserve.villa_id = villa.id
+                    where reserve.date <= now() and user_id = :id";
+
+        // SQLをプリペア
+        $statement = $this->db->prepare($sql);
+
+        // user_idを指定します
+        $statement->bindParam(":id", $user_id, PDO::PARAM_INT);
+
+        // SQLを実行
+        $statement->execute();
+
+        // 結果レコードを一件取得し、返送
+        return $statement->fetchAll();
+    }
+
+    /**
+     * getFutureReserveByVilla Function
+     *
+     * Reserveテーブルから指定user_idの明日以降のレコードを全件取得するクエリです。
+     *
+     * @param int $user_id 引数として、取得したい予約記録を指定します。
+     * @return array $result 結果情報を連想配列を返します。
+     * @throws DBALException
+     * @author wkmkymt <wkmkymt@gmail.com>
+     * @since 2019/09/06
+     */
+    public function getFutureReserveByUser($user_id)
+    {
+        // user_idを指定して取得するクエリを作成
+        $sql = "select reserve.date, villa.id, villa.name, villa.image_path
+                    from reserve inner join villa on reserve.villa_id = villa.id
+                    where reserve.date > now() and user_id = :id";
+
+        // SQLをプリペア
+        $statement = $this->db->prepare($sql);
+
+        // user_idを指定します
+        $statement->bindParam(":id", $user_id, PDO::PARAM_INT);
+
+        // SQLを実行
+        $statement->execute();
+
+        // 結果レコードを一件取得し、返送
+        return $statement->fetchAll();
+    }
+
     public static function formatReserveList($reserves)
     {
         $reserve_list = [];

--- a/app/Model/Dao/Reserve.php
+++ b/app/Model/Dao/Reserve.php
@@ -69,7 +69,8 @@ class Reserve extends Dao
         // user_idを指定して取得するクエリを作成
         $sql = "select reserve.date, villa.id, villa.name, villa.image_path
                     from reserve inner join villa on reserve.villa_id = villa.id
-                    where reserve.date <= now() and user_id = :id";
+                    where reserve.date <= now() and user_id = :id
+                    limit 6";
 
         // SQLをプリペア
         $statement = $this->db->prepare($sql);
@@ -100,7 +101,8 @@ class Reserve extends Dao
         // user_idを指定して取得するクエリを作成
         $sql = "select reserve.date, villa.id, villa.name, villa.image_path
                     from reserve inner join villa on reserve.villa_id = villa.id
-                    where reserve.date > now() and user_id = :id";
+                    where reserve.date > now() and user_id = :id
+                    limit 6";
 
         // SQLをプリペア
         $statement = $this->db->prepare($sql);


### PR DESCRIPTION
close #33 

+ マイページ(?)に今日以前の宿泊履歴と明日以降の宿泊予定を投げるロジックを実装

```
array:2 [▼
  "past_reserve" => array:2 [▼
    0 => array:4 [▼
      "date" => "2019-09-05"
      "id" => "1"
      "name" => "森と海を堪能できる山口"
      "image_path" => "https://www.resort-home.jp/blog/photo/2018.2.1.jpg"
    ]
    1 => array:4 [▼
      "date" => "2019-09-06"
      "id" => "1"
      "name" => "森と海を堪能できる山口"
      "image_path" => "https://www.resort-home.jp/blog/photo/2018.2.1.jpg"
    ]
  ]
  "future_reserve" => array:2 [▼
    0 => array:4 [▼
      "date" => "2019-10-20"
      "id" => "1"
      "name" => "森と海を堪能できる山口"
      "image_path" => "https://www.resort-home.jp/blog/photo/2018.2.1.jpg"
    ]
    1 => array:4 [▼
      "date" => "2019-09-22"
      "id" => "2"
      "name" => "自然と調和した一軒"
      "image_path" => "https://ggo.ismcdn.jp/mwimgs/e/3/-/img_e338c8ddf4044a67f778d28f60ac0197151230.jpg"
    ]
  ]
]
```